### PR TITLE
Fix issue with 'id' parameter not working

### DIFF
--- a/shortcodes/SqlTableShortcode.php
+++ b/shortcodes/SqlTableShortcode.php
@@ -59,7 +59,7 @@ class SqlTableShortcode extends Shortcode
                             'rows' => $rows,
                             'hidden' => $hidden,
                             'class' => isset( $params['class']) ? $params['class'] : '',
-                            'id' => isset($params['id']) ? $param['id'] : ''
+                            'id' => isset($params['id']) ? $params['id'] : ''
                         ]
                     );
                 }

--- a/templates/partials/sql-table.html.twig
+++ b/templates/partials/sql-table.html.twig
@@ -1,4 +1,4 @@
-<table{% if class %} class="{{ class }}"{% endif %}{% if id %} id="{{ class }}"{% endif %}>
+<table{% if class %} class="{{ class }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}>
   <thead>
     <tr>
       {% for item in fields %}


### PR DESCRIPTION
It should be possible to set an `id` parameter on the `sql-table`
shortcode (e.g. `[sql-table id=foo]`) that will be propagated to the
`id` attribute on the rendered table.

There were two separate problems that prevented the `id` parameter from
taking effect:

 1.  A typo meant that the parameter was not being passed through to the
     template.
 2.  The template was setting the `id` to the value of the `class`
     parameter instead of the `id` one.

Now fixed and working.