### PR TITLE
CHANGELOG incompatibility with GPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,81 +1,77 @@
 # v1.5.4
-## 22 Dec 2020
-1. [](#typo)
-``* fixed readme
+## 22-12-2020
+1. [](#enhancement)
+   * fixed readme
 
 # v1.5.3
-## 18 July 2020
-1. []](#bugfix) Extra security measure added - credit @hughbris
+## 18-07-2020
+1. [](#bugfix) 
+   * Extra security measure added - credit @hughbris
 
 # v1.5.2
-## 19 December 2018
+## 19-12-2018
 1. [](#bugfix)
-    * propagate id in shortcode to table,
-    * credit to Matt Marsh @marshmn
-2. [](#bugfix)
-    * log function at line 16 SqlTableShortcode requires two parameters, not one.
-    * credit to @dlannan
+   * propagate id in shortcode to table,
+   * credit to Matt Marsh @marshmn
+   * log function at line 16 SqlTableShortcode requires two parameters, not one.
+   * credit to @dlannan
 
 # v1.5.1
-## 1 August 2018
-1. [](#documentation)
-    * A more elaborate example is added to show how to obtain data from a database, change data by  creating a form, then update the row in the database.
+## 01-08-2018
+1. [](#enhancement)
+   * A more elaborate example is added to show how to obtain data from a database, change data by  creating a form, then update the row in the database.
 
 # v1.5.0
-## 16 June 2018
+## 16-06-2018
 1. [](#enhancement)
-    * Extra security option. Allows for more paranoia
-    * When enabled, each page with an [sql-table] shortcode must have explicit header permission
-        * This is to prevent shortcode being added in the front end by an editor
-1. [](#minorbug)
-    * fix file permission from 0666 to 0664
+   * Extra security option. Allows for more paranoia
+   * When enabled, each page with an [sql-table] shortcode must have explicit header permission
+   * This is to prevent shortcode being added in the front end by an editor
+1. [](#bugfix)
+   * fix file permission from 0666 to 0664
 
 # v1.4.0
-## 23 June 2018
+## 23-06-2018
 1. [](#enhancement)
-    * More logging options, allowing for the SELECT, INSERT and UPDATE stanzas (in addition to Errors)
-    to be trapped.
-    * Append the logged data to the directory `user/data/sqlite` as a 'log.txt' file
-        * This allows an Administrator to view the data from within the Admin panel using the DataManager plugin.
-2. [](#change of configuration)
-    * The default configuration for the placement of the sqlite3 database is now `user/data/sqlite`
+   * More logging options, allowing for the SELECT, INSERT and UPDATE stanzas (in addition to Errors)
+   to be trapped.
+   * Append the logged data to the directory `user/data/sqlite` as a 'log.txt' file
+   * This allows an Administrator to view the data from within the Admin panel using the DataManager plugin.
+   * The default configuration for the placement of the sqlite3 database is now `user/data/sqlite`
 
 # v1.3.0
-## 11 June 2018
+## 11-06-2018
 1. [](#enhancement)
-    * Add `ignore` field in `sql-insert` and `sql-update`
-    * Add `error_logging` configuration option, so that SQL errors are written to hard drive
+   * Add `ignore` field in `sql-insert` and `sql-update`
+   * Add `error_logging` configuration option, so that SQL errors are written to hard drive
 
 # v1.2.3
-## 7 June 2018
-1. [](#update)
-    * Add shortcode dependency to blueprints
+## 07-07-2018
+1. [](#enhancement)
+   * Add shortcode dependency to blueprints
 
 # v1.2.2
-##  5/05/2018
-1. [*](#bug and enhancement)
-    * Process `sqlite-insert` corrected to `sql-insert`
-    * Removed fields provided by `Form` plugin, viz. `_xxx` & `form-nonce`
+## 05-05-2018
+1. [](#bugfix)
+   * Process `sqlite-insert` corrected to `sql-insert`
+   * Removed fields provided by `Form` plugin, viz. `_xxx` & `form-nonce`
 
 # v1.2.1
-##  5 May 2018
-1. [*](#minor)
-        * error in translate call
+## 05-05-2018
+1. [](#bugfix)
+  * error in translate call
 
-#v1.2.0
-##  28 April 2018
-1. [*](#major )
-    * Allow for Twig variables to be used in SELECT stanza in shortcode, and in 'where' field of UPDATE Form process.
+# v1.2.0
+## 28-04-2018
+1. [](#bugfix)
+   * Allow for Twig variables to be used in SELECT stanza in shortcode, and in 'where' field of UPDATE Form process.
 
-# v1.0.0 - v1.2.0
-##  < 28 April 2018
+# v1.0.0
+## 31-01-2018
 
-1. [*](#new)
-    * Initial work
-2. [*](#minor)
-    * Removal of debug code/messages
-    * refactor in case of zero data in form.
-3. [*](#minor)
-    * Allow for `where` to be a Form Field as well as a Process parameters
-4. [*](#major)
-    * New sql option to provide json serialisation instead of HTML serialisation of data
+1. [](#new)
+   * Initial work
+   * Removal of debug code/messages
+   * refactor in case of zero data in form.
+   * Allow for `where` to be a Form Field as well as a Process parameters
+   * New sql option to provide json serialisation instead of HTML serialisation of data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.5.4
 ## 22-12-2020
-1. [](#enhancement)
+1. [](#improved)
    * fixed readme
 
 # v1.5.3
@@ -18,12 +18,12 @@
 
 # v1.5.1
 ## 01-08-2018
-1. [](#enhancement)
+1. [](#improved)
    * A more elaborate example is added to show how to obtain data from a database, change data by  creating a form, then update the row in the database.
 
 # v1.5.0
 ## 16-06-2018
-1. [](#enhancement)
+1. [](#improved)
    * Extra security option. Allows for more paranoia
    * When enabled, each page with an [sql-table] shortcode must have explicit header permission
    * This is to prevent shortcode being added in the front end by an editor
@@ -32,7 +32,7 @@
 
 # v1.4.0
 ## 23-06-2018
-1. [](#enhancement)
+1. [](#improved)
    * More logging options, allowing for the SELECT, INSERT and UPDATE stanzas (in addition to Errors)
    to be trapped.
    * Append the logged data to the directory `user/data/sqlite` as a 'log.txt' file
@@ -41,13 +41,13 @@
 
 # v1.3.0
 ## 11-06-2018
-1. [](#enhancement)
+1. [](#improved)
    * Add `ignore` field in `sql-insert` and `sql-update`
    * Add `error_logging` configuration option, so that SQL errors are written to hard drive
 
 # v1.2.3
 ## 07-07-2018
-1. [](#enhancement)
+1. [](#improved)
    * Add shortcode dependency to blueprints
 
 # v1.2.2


### PR DESCRIPTION
Hello @finanalyst,

I have noticed in our GPM logs that your plugin's CHANGELOG is not compatible with GPM. Our GPM is quite sensible to the way the CHANGELOG is structured and it does require consistency. This PR should fix the problem for you and I also wanted to highlight what type of changes I have made for you to know in the future.

1. **Sections**: We only support `new`, `bugfix` and `improved` as sections of a changelog. Would be great to support some of the ones you came up with such as **documentation**, **minor**, **change** but at this time we do not support those.
   Also, don't group multiple entires of the section name. Only 1 `[](#bugfix)` per version should be present.
2. **Date Format**: The date format we support is only US or EU in the short numeric notation. For US, today would be `12/23/2020` for EU today's format would be `23-12-2020`. I have updated all your dates to reflect that.
  Also, the date is quite important to be just a date, the format `< 28 April 2018` is not supported. I did set that date for you to `31-01-2018` which appears to be your very first commit on the repository.
3. **Version Format**: Although a range of versions is ok and will work (`# v1.0.0 - v1.2.0`), CHANGELOGs are supposed to be the journal of each singular version. Particularly in Grav we have a feature that allows to display the CHANGELOG of a resource from the current version installed to the latest available. This would not work if the version definition was in range format.